### PR TITLE
Ram rom bugfixes

### DIFF
--- a/src/devices.zig
+++ b/src/devices.zig
@@ -46,7 +46,7 @@ pub fn createDevice(allocator: std.mem.Allocator, system_dir: std.fs.Dir, config
     var peripheral = switch (device) {
         .keyboard => (try builtin.Keyboard.init(allocator)).peripheral(),
         .ram => (try builtin.RAM.init(allocator, config.size())).peripheral(),
-        .rom => (try builtin.ROM.init(allocator)).peripheral(),
+        .rom => (try builtin.ROM.init(allocator, 0)).peripheral(),
         .terminal => (try builtin.Terminal.init(allocator, &system_config.video)).peripheral(),
         .@"text-terminal" => (try builtin.TextTerminal.init(allocator)).peripheral(),
         .@"via.w65c22" => (try via.W65c22.init(allocator)).peripheral(),

--- a/src/devices/builtin/memory.zig
+++ b/src/devices/builtin/memory.zig
@@ -11,6 +11,7 @@ fn Memory(comptime TReadonly: bool) type {
 
         // Actual data, always just use a fixed 64k
         data: [0x1_0000]u8 = [_]u8{0} ** 0x1_0000,
+        // Excess-1 notation, so that the full memory range can be used. Zero size memory is not possible.
         size: u16,
 
         /// Initialise RAM/ROM device.
@@ -40,14 +41,8 @@ fn Memory(comptime TReadonly: bool) type {
         /// Read a value from the a peripheral register.
         fn read(ctx: *anyopaque, addr: u16) PeripheralError!u8 {
             const self: *Self = @ptrCast(@alignCast(ctx));
-            if (TReadonly) {
-                if (addr >= self.size) {
-                    return PeripheralError.AddressIndex;
-                }
-            } else {
-                if (addr > self.size) {
-                    return PeripheralError.AddressIndex;
-                }
+            if (addr >= self.size) {
+                return PeripheralError.AddressIndex;
             }
             return self.data[addr];
         }
@@ -76,7 +71,7 @@ fn Memory(comptime TReadonly: bool) type {
         /// View of registers
         fn registers(ctx: *anyopaque) PeripheralError![]u8 {
             const self: *Self = @ptrCast(@alignCast(ctx));
-            return self.data[0..self.size];
+            return self.data[0 .. self.size + 1];
         }
     };
 }

--- a/src/devices/builtin/memory.zig
+++ b/src/devices/builtin/memory.zig
@@ -65,7 +65,9 @@ fn Memory(comptime TReadonly: bool) type {
             const self: *Self = @ptrCast(@alignCast(ctx));
             if (data.len > self.data.len) return PeripheralError.AddressIndex;
             @memcpy(self.data[0..data.len], data);
-            self.size = @truncate(data.len - 1);
+            if (TReadonly) {
+                self.size = @truncate(data.len - 1);
+            }
         }
 
         /// View of registers

--- a/src/devices/builtin/memory.zig
+++ b/src/devices/builtin/memory.zig
@@ -5,130 +5,92 @@ const std = @import("std");
 const Peripheral = @import("../../peripheral.zig");
 const PeripheralError = Peripheral.PeripheralError;
 
+fn Memory(comptime TReadonly: bool) type {
+    return struct {
+        const Self = @This();
+
+        // Actual data, always just use a fixed 64k
+        data: [0x1_0000]u8 = [_]u8{0} ** 0x1_0000,
+        size: u16 = if (TReadonly) 0 else 0xFFFF,
+
+        /// Initialise RAM/ROM device.
+        pub fn init(allocator: std.mem.Allocator, size: u16) !*Self {
+            const instance = try allocator.create(Self);
+            if (TReadonly) {
+                instance.* = .{};
+            } else {
+                instance.* = .{
+                    .size = size,
+                };
+            }
+            return instance;
+        }
+
+        /// Fetch the peripheral interface
+        pub fn peripheral(self: *Self) Peripheral {
+            return .{
+                .ptr = self,
+                .vtable = &.{
+                    .name = if (TReadonly) "ROM" else "RAM",
+                    .description = if (TReadonly) "Read Only Memory." else "Random Access Memory.",
+                    .read = read,
+                    .write = write,
+                    .load = load,
+                    .registers = registers,
+                },
+            };
+        }
+
+        /// Read a value from the a peripheral register.
+        fn read(ctx: *anyopaque, addr: u16) PeripheralError!u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            if (TReadonly) {
+                if (addr >= self.size) {
+                    return PeripheralError.AddressIndex;
+                }
+            } else {
+                if (addr > self.size) {
+                    return PeripheralError.AddressIndex;
+                }
+            }
+            return self.data[addr];
+        }
+
+        /// Write a value to a peripheral register.
+        fn write(ctx: *anyopaque, addr: u16, data: u8) PeripheralError!void {
+            if (TReadonly) {
+                return PeripheralError.ReadOnly;
+            }
+
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            if (addr >= self.size) {
+                return PeripheralError.AddressIndex;
+            }
+            self.data[addr] = data;
+        }
+
+        /// Load a file image (up to 64k).
+        fn load(ctx: *anyopaque, data: []const u8) PeripheralError!void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            if (data.len > self.data.len) return PeripheralError.AddressIndex;
+            @memcpy(self.data[0..data.len], data);
+            self.size = @truncate(data.len - 1);
+        }
+
+        /// View of registers
+        fn registers(ctx: *anyopaque) PeripheralError![]u8 {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            return self.data[0..self.size];
+        }
+    };
+}
+
 /// RAM device.
-pub const RAM = struct {
-    const Self = @This();
-
-    // Actual data, always just use a fixed 64k
-    data: [0x1_0000]u8 = [_]u8{0} ** 0x1_0000,
-    size: u16 = 0xFFFF,
-
-    /// Initialise RAM device.
-    pub fn init(allocator: std.mem.Allocator, size: u16) !*Self {
-        const instance = try allocator.create(Self);
-        instance.* = .{
-            .size = size,
-        };
-        return instance;
-    }
-
-    /// Fetch the peripheral interface
-    pub fn peripheral(self: *Self) Peripheral {
-        return .{
-            .ptr = self,
-            .vtable = &.{
-                .name = "RAM",
-                .description = "Random Access Memory.",
-                .read = read,
-                .write = write,
-                .load = load,
-                .registers = registers,
-            },
-        };
-    }
-
-    /// Read a value from the a peripheral register.
-    fn read(ctx: *anyopaque, addr: u16) PeripheralError!u8 {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        if (addr > self.size) {
-            return PeripheralError.AddressIndex;
-        }
-        return self.data[addr];
-    }
-
-    /// Write a value to a peripheral register.
-    fn write(ctx: *anyopaque, addr: u16, data: u8) PeripheralError!void {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        if (addr >= self.size) {
-            return PeripheralError.AddressIndex;
-        }
-        self.data[addr] = data;
-    }
-
-    /// Load a file image (up to 64k).
-    fn load(ctx: *anyopaque, data: []const u8) PeripheralError!void {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        if (data.len > self.data.len) return PeripheralError.AddressIndex;
-        @memcpy(self.data[0..data.len], data);
-        self.size = @truncate(data.len - 1);
-    }
-
-    /// View of registers
-    fn registers(ctx: *anyopaque) PeripheralError![]u8 {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        return self.data[0..self.size];
-    }
-};
+pub const RAM = Memory(false);
 
 /// **ROM device**
 ///
 /// A ROM device has an initial size or zero that changes depending on data
 /// loaded into the ROM. If a binary image is loaded the ROM will be set to
 /// the size of the loaded image.
-pub const ROM = struct {
-    const Self = @This();
-
-    // Actual data, always just use a fixed 64k
-    data: [0x1_0000]u8 = [_]u8{0} ** 0x1_0000,
-    size: u16 = 0,
-
-    /// Initialise ROM device.
-    pub fn init(allocator: std.mem.Allocator) !*Self {
-        const instance = try allocator.create(Self);
-        instance.* = .{};
-        return instance;
-    }
-
-    /// Fetch the peripheral interface
-    pub fn peripheral(self: *Self) Peripheral {
-        return .{
-            .ptr = self,
-            .vtable = &.{
-                .name = "ROM",
-                .description = "Read Only Memory.",
-                .read = read,
-                .write = write,
-                .load = load,
-                .registers = registers,
-            },
-        };
-    }
-
-    /// Read a value from the a peripheral register.
-    fn read(ctx: *anyopaque, addr: u16) PeripheralError!u8 {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        if (addr >= self.size) {
-            return PeripheralError.AddressIndex;
-        }
-        return self.data[addr];
-    }
-
-    /// Write a value to a peripheral register.
-    fn write(_: *anyopaque, _: u16, _: u8) PeripheralError!void {
-        return PeripheralError.ReadOnly;
-    }
-
-    /// Load a file image (up to 64k).
-    fn load(ctx: *anyopaque, data: []const u8) PeripheralError!void {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        if (data.len > self.data.len) return PeripheralError.AddressIndex;
-        @memcpy(self.data[0..data.len], data);
-        self.size = @truncate(data.len - 1);
-    }
-
-    /// View of registers
-    fn registers(ctx: *anyopaque) PeripheralError![]u8 {
-        const self: *Self = @ptrCast(@alignCast(ctx));
-        return self.data[0..self.size];
-    }
-};
+pub const ROM = Memory(true);

--- a/src/devices/builtin/memory.zig
+++ b/src/devices/builtin/memory.zig
@@ -11,18 +11,14 @@ fn Memory(comptime TReadonly: bool) type {
 
         // Actual data, always just use a fixed 64k
         data: [0x1_0000]u8 = [_]u8{0} ** 0x1_0000,
-        size: u16 = if (TReadonly) 0 else 0xFFFF,
+        size: u16,
 
         /// Initialise RAM/ROM device.
         pub fn init(allocator: std.mem.Allocator, size: u16) !*Self {
             const instance = try allocator.create(Self);
-            if (TReadonly) {
-                instance.* = .{};
-            } else {
-                instance.* = .{
-                    .size = size,
-                };
-            }
+            instance.* = .{
+                .size = size,
+            };
             return instance;
         }
 


### PR DESCRIPTION
The structs for RAM and ROM had a lot of duplication, so I joined them to a single Memory struct with a comptime TReadonly parameter.

This revealed a couple of bugs and inconsistencies in how the size property was used.

I have not really been able to actually RUN the code, since some unrelated parts seem to be broken on macos, but the changes look sensible to me. Please test it yourself.